### PR TITLE
[PIP-118] Define CI/CD workflow template for SG toolkit

### DIFF
--- a/.github/workflows/sg_toolkit_workflow.yml
+++ b/.github/workflows/sg_toolkit_workflow.yml
@@ -24,11 +24,11 @@ jobs:
           # ref: ${{ github.sha }}
           fetch-depth: '0'  #  Required due to the way Git works, without it this action won't be able to find any or the correct tags
 
-      - name: Print out organization variables and secrets
-        run: |
-          echo ${{ vars.SG_BASE_URL }}
-          echo ${{ vars.SG_SCRIPT_NAME }}
-          echo ${{ secrets.sg-api-key }}
+      # - name: Print out organization variables and secrets
+      #   run: |
+      #     echo ${{ vars.SG_BASE_URL }}
+      #     echo ${{ vars.SG_SCRIPT_NAME }}
+      #     echo ${{ secrets.sg-api-key }}
 
       - name: 'Get Previous tag'
         id: previoustag
@@ -58,7 +58,7 @@ jobs:
           custom_tag: ${{ steps.increment_version.outputs.version }}
           tag_prefix: ''  # Ignore 'v' prefix because custom_tag has 'v' prefix alreeady
 
-      - name: Create Pre-release
+      - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -119,16 +119,16 @@ jobs:
       # - name: Download asset from ci-cd-workflows repo
       #   run: curl -H "${{ steps.variable_fixtures.outputs.authorization_header }}" -L "https://api.github.com/repos/Falcons-Creative-Group/ci-cd-workflows/zipball/v0.0.1" > ci-cd-workflows-v0.0.1.zip
 
-      - name: Checkout ci-cd-workflows repo
+      - name: Checkout ci-cd-workflows repo to ci-cd-workflows folder
         uses: actions/checkout@v3
         with:
           repository: 'Falcons-Creative-Group/ci-cd-workflows'
           path: ci-cd-workflows
     
-      - name: Print Files in Workspace
-        run: |
-          cd ${{ github.workspace }}/ci-cd-workflows
-          ls -la
+      # - name: Print Files in Workspace
+      #   run: |
+      #     cd ${{ github.workspace }}/ci-cd-workflows
+      #     ls -la
 
       - name: Create SG Pipeline Config and upload zip file
         run: python pipeline_config_uploader.py

--- a/.github/workflows/sg_toolkit_workflow.yml
+++ b/.github/workflows/sg_toolkit_workflow.yml
@@ -1,8 +1,18 @@
-name: Reusable workflow example
+name: ShotGrid Toolkit Workflow
 
 on:
   workflow_call:
-
+    secrets:
+      sg-api-key:
+        required: true
+        description: 'ShotGrid API Key'
+    inputs:
+      is-prerelease:
+        description: 'Is this a pre-release?'
+        required: true
+        type: boolean
+        default: true
+        
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,6 +20,123 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # ref: ${{ github.sha }}
+          fetch-depth: '0'  #  Required due to the way Git works, without it this action won't be able to find any or the correct tags
 
-      - name: Print Hello World
-        run: echo "Hello World"
+      - name: Print out organization variables and secrets
+        run: |
+          echo ${{ vars.SG_BASE_URL }}
+          echo ${{ vars.SG_SCRIPT_NAME }}
+          echo ${{ secrets.sg-api-key }}
+
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "Falcons-Creative-Group/github-action-get-previous-tag@v1"
+
+      - name: Print out previous tag
+        run: echo ${{ steps.previoustag.outputs.tag }}
+
+      - name: Bump version
+        id: increment_version
+        run: |
+          last_version=${{ steps.previoustag.outputs.tag }}
+          last_number=$(echo $last_version | awk -F. '{print $NF}')
+          next_number=$((last_number + 1))
+          new_version=$(echo $last_version | sed "s/\.[0-9]*$/.${next_number}/")
+          echo "version=$new_version" >> $GITHUB_OUTPUT
+          echo ${version}
+        
+      - name: Print out new version
+        run: echo ${{ steps.increment_version.outputs.version }}
+      
+      - name: Push tag
+        id: tag_version
+        uses: Falcons-Creative-Group/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.increment_version.outputs.version }}
+          tag_prefix: ''  # Ignore 'v' prefix because custom_tag has 'v' prefix alreeady
+
+      - name: Create Pre-release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+          draft: false
+          prerelease: ${{ inputs.is-prerelease }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9  # Adjust the version to match your requirements
+
+      - name: Install ShotGrid Python API
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/shotgunsoftware/python-api.git
+
+      - name: Variable Fixtures
+        id: variable_fixtures
+        run: |
+          repository=${{ github.repository }}
+          repo_name=${repository#*/}
+          authorization_header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+          download_url=https://api.github.com/repos/${{ github.repository }}/zipball/${{ steps.tag_version.outputs.new_tag }}
+          zip_file_name="$repo_name-${{ steps.tag_version.outputs.new_tag }}.zip"
+          zip_file_path=${{ github.workspace }}/$zip_file_name
+          branch_name=${{ github.ref_name }}
+          config_name="$branch_name_${{ steps.tag_version.outputs.new_tag }}"
+          config_description="Pipeline Config for ${{ steps.tag_version.outputs.new_tag }}"
+          echo "Repository Name: $repo_name"
+          echo "Authorization Header: $authorization_header"
+          echo "Download URL: $download_url"
+          echo "Zip File Name: $zip_file_name"
+          echo "Zip File Path: $zip_file_path"
+          echo "Config Name: $config_name"
+          echo "Config Description: $config_description"
+
+          echo "authorization_header=$authorization_header" >> $GITHUB_OUTPUT
+          echo "download_url=$download_url" >> $GITHUB_OUTPUT
+          echo "zip_file_name=$zip_file_name" >> $GITHUB_OUTPUT
+          echo "zip_file_path=$zip_file_path" >> $GITHUB_OUTPUT
+          echo "config_name=$config_name" >> $GITHUB_OUTPUT
+          echo "config_description=$config_description" >> $GITHUB_OUTPUT
+
+      - name: Print variable fixtures
+        run: |
+          echo ${{ steps.variable_fixtures.outputs.authorization_header }}
+          echo ${{ steps.variable_fixtures.outputs.download_url }}
+          echo ${{ steps.variable_fixtures.outputs.zip_file_name }}
+
+      - name: Download Zip File from Release
+        run: curl -H "${{ steps.variable_fixtures.outputs.authorization_header }}" -L "${{ steps.variable_fixtures.outputs.download_url }}" > ${{ steps.variable_fixtures.outputs.zip_file_name }}
+
+      # - name: Download asset from ci-cd-workflows repo
+      #   run: curl -H "${{ steps.variable_fixtures.outputs.authorization_header }}" -L "https://api.github.com/repos/Falcons-Creative-Group/ci-cd-workflows/zipball/v0.0.1" > ci-cd-workflows-v0.0.1.zip
+
+      - name: Checkout ci-cd-workflows repo
+        uses: actions/checkout@v3
+        with:
+          repository: 'Falcons-Creative-Group/ci-cd-workflows'
+          path: ci-cd-workflows
+    
+      - name: Print Files in Workspace
+        run: |
+          cd ${{ github.workspace }}/ci-cd-workflows
+          ls -la
+
+      - name: Create SG Pipeline Config and upload zip file
+        run: python pipeline_config_uploader.py
+        working-directory: ${{ github.workspace }}/ci-cd-workflows
+        env:
+          SG_BASE_URL: ${{ vars.SG_BASE_URL }}
+          SG_SCRIPT_NAME: ${{ vars.SG_SCRIPT_NAME }}
+          SG_SCRIPT_KEY: ${{ secrets.sg-api-key }}
+          CONFIG_NAME: ${{ steps.variable_fixtures.outputs.config_name }}
+          CONFIG_DESCRIPTION: ${{ steps.variable_fixtures.outputs.config_description }}
+          ZIP_FILE_PATH: ${{ steps.variable_fixtures.outputs.zip_file_path }}

--- a/.github/workflows/sg_toolkit_workflow.yml
+++ b/.github/workflows/sg_toolkit_workflow.yml
@@ -90,7 +90,7 @@ jobs:
           zip_file_name="$repo_name-${{ steps.tag_version.outputs.new_tag }}.zip"
           zip_file_path=${{ github.workspace }}/$zip_file_name
           branch_name=${{ github.ref_name }}
-          config_name="$branch_name_${{ steps.tag_version.outputs.new_tag }}"
+          config_name="$branch_name-${{ steps.tag_version.outputs.new_tag }}"
           config_description="Pipeline Config for ${{ steps.tag_version.outputs.new_tag }}"
           echo "Repository Name: $repo_name"
           echo "Authorization Header: $authorization_header"


### PR DESCRIPTION
Updated the workflow by adding the following steps:

- Get the latest tag
- Increment the tag
- Create a GitHub Release
- Download the Zip File from the GitHub release to the workspace
- Check out the ci-cd-workflows repository to the ci-cd-workflows folder
- Run a Python script from the ci-cd-workflows folder, passing the following parameters: SG site URL, SG script name, SG script key, config name, config description, and the path of the downloaded zip file.

Additionally, introduced the `is-prerelease` boolean variable that is passed from the caller workflow. This variable will determine whether it will create a release or a pre-release.

Associated Jira issue: [PIP-118](https://falconsbeyond.atlassian.net/browse/PIP-118?atlOrigin=eyJpIjoiYmQ0ZjE5ZTY5MDU4NGRhOTlkYWVkYjZhMjgxZGE0NDgiLCJwIjoiaiJ9)