### PR TITLE
[PIP-138] Add default branch parameter

### DIFF
--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -2,6 +2,12 @@ name: Prerelease Check
 
 on:
   workflow_call:
+    inputs:
+      default-branch:
+        type: string
+        description: 'The default branch of the repository'
+        required: true
+        default: 'main'
     outputs:
       is-prerelease:
         description: 'Is this a prerelease?'
@@ -19,7 +25,7 @@ jobs:
       - name: Determine if this is a prerelease
         id: determine-is-prerelease
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/master" && "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/${{ inputs.default-branch }}" && "${{ github.event_name }}" == "push" ]]; then
             echo "is-prerelease=false" >> $GITHUB_OUTPUT
           else
             echo "is-prerelease=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -6,7 +6,7 @@ on:
       default-branch:
         type: string
         description: 'The default branch of the repository'
-        required: true
+        required: false
         default: 'main'
     outputs:
       is-prerelease:


### PR DESCRIPTION
Added default branch parameter to prerelease-check workflow template due to a mix of `main` and `master` as default branch name across our repositories. 