### PR TITLE
[PIP-349] Use annotated tag

### DIFF
--- a/.github/workflows/release-to-github.yml
+++ b/.github/workflows/release-to-github.yml
@@ -54,6 +54,7 @@ jobs:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             custom_tag: ${{ steps.increment_version.outputs.version }}
             tag_prefix: ''  # Ignore 'v' prefix because custom_tag has 'v' prefix alreeady
+            create_annotated_tag: true
 
         - name: Create GitHub Release
           id: create_release


### PR DESCRIPTION
Tags created by the CI/CD workflow are lightweight, meaning they do not have unique timestamps and are just pointers to specific commits. Consequently, when there are multiple lightweight tags on the same commit, the `get-previous-tag-action` retrieve an incorrect previous tag. Use an annotated tag instead of lightweight during tag creation process. 