### PR TITLE
PIP-381 Update workflow template to support sg workflow in monorepo

### DIFF
--- a/.github/workflows/pipe-config-pipeline.yml
+++ b/.github/workflows/pipe-config-pipeline.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: boolean
         default: true
-        
+
 jobs:
   release:
     name: Create Release
@@ -20,7 +20,7 @@ jobs:
     secrets: inherit
     with:
       is-prerelease: ${{ inputs.is-prerelease }}
-  
+
   deploy:
     name: Deploy to ShotGrid
     needs: release
@@ -30,3 +30,4 @@ jobs:
       is-prerelease: ${{ inputs.is-prerelease }}
       release-version: ${{ needs.release.outputs.version }}
       release-html-url: ${{ needs.release.outputs.html-url }}
+      prepend-repo-name: true

--- a/.github/workflows/release-to-pipe-config.yml
+++ b/.github/workflows/release-to-pipe-config.yml
@@ -20,6 +20,11 @@ on:
             required: true
             type: string
             default: ''
+        prepend-repo-name:
+            description: 'Prepend the repository name to the zip file name'
+            required: false
+            type: boolean
+            default: false
 
 jobs:
   deploy:
@@ -34,7 +39,11 @@ jobs:
           repo_name=${repository#*/}
           authorization_header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
           download_url=https://api.github.com/repos/${{ github.repository }}/zipball/${{ inputs.release-version }}
-          zip_file_name="$repo_name-${{ inputs.release-version }}.zip"
+          if ${{ inputs.prepend-repo-name }}; then
+            zip_file_name="$repo_name-${{ inputs.release-version }}.zip"
+          else
+            zip_file_name="${{ inputs.release-version }}.zip"
+          fi
           zip_file_path=${{ github.workspace }}/$zip_file_name
           if ${{ inputs.is-prerelease }}; then
             config_name_prefix=${{ github.ref_name }}

--- a/.github/workflows/release-to-pipe-config.yml
+++ b/.github/workflows/release-to-pipe-config.yml
@@ -1,5 +1,9 @@
 on:
     workflow_call:
+      secrets:
+        sg-api-key:
+          required: true
+          description: 'ShotGrid API Key'
       inputs:
         is-prerelease:
             description: 'Is this a pre-release?'


### PR DESCRIPTION
**Updated Workflow for Deploying Assets to Pipeline Config Entity**

This update introduces several key changes to the asset deployment workflow:

1. **Secrets Input:** We've added a new input parameter to pass the ShotGrid API key from the workflow caller. This ensures secure handling of sensitive information. For reference, see the implementation in our [tk-config-default2_deploy.yml](https://github.com/Falcons-Creative-Group/fcm/pull/19/files#diff-00867c054b9dd9a96451f8abddac64ba42abbe46a2e1054639e42e9902fb578e).

2. **Prepend Repository Name:** A new boolean input, `prepend-repo-name`, has been introduced. This determines whether the repository name should be prepended to the zip file name. This adjustment is necessary because our tags, such as `v1.4.5.1` in the [tk-config-default2](https://github.com/Falcons-Creative-Group/tk-config-default2) repo, only include the version number. The workflow fetches the repository name using `${repository#*/}` and combines it with the release version to create the zip filename. This ad hoc fix supports both the current workflow and the newer workflow in the monorepo, where the full filename of the zip file is provided, and thus, the `prepend-repo-name` is disabled.